### PR TITLE
[develop] Version/4.16.0

### DIFF
--- a/.github/workflows/wf-branch-alfa.yml
+++ b/.github/workflows/wf-branch-alfa.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Check Environment Variables
         run: |
-          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' ||  env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.FIRST_HEIGHT == ''  ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
+          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' ||  env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
             echo "Error: one or more environment variables are not set."
             exit 1
           else

--- a/.github/workflows/wf-branch-development.yml
+++ b/.github/workflows/wf-branch-development.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Check Environment Variables
         run: |
-          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' || env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.FIRST_HEIGHT == ''  ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
+          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' || env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
             echo "Error: one or more environment variables are not set."
             exit 1
           else

--- a/.github/workflows/wf-branch-master.yml
+++ b/.github/workflows/wf-branch-master.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Check Environment Variables
         run: |
-          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' ||  env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.FIRST_HEIGHT == ''  ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
+          if ${{ env.ANCESTORS_LIST == '' ||  env.API_VERSION == '' ||  env.API_VERSION_COSMWASM == '' ||  env.BACKEND == '' ||  env.BACKEND_WS == '' ||  env.CONNECTIONS == '' ||  env.CONTRACT_DEX == '' ||  env.FIRST_CONVERSION_RATE == '' ||  env.HAS_POOLS == '' ||  env.LCD_URL == '' ||  env.MAIN_TITLE == '' ||  env.WASM_CW20_CODE_ID == '' ||  env.WASM_SWAP_CODE_ID == '' ||  env.WS_URL == '' }}; then
             echo "Error: one or more environment variables are not set."
             exit 1
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ Entries for versions prior to `4.0.0` have been moved to
 
 ## [4.16.0] - 2026-06-09
 
+### Changed
+
+- Auto-detect the node's lowest available block height instead of relying
+  on `VUE_APP_FIRST_HEIGHT`. On startup the explorer probes the node and,
+  on a pruning node, reads the lowest height it reports; the env variable
+  is now an optional fallback used only when the node does not provide it.
+  This keeps the blocks list and search bounds aligned with the node as it
+  prunes, without manual reconfiguration
+
 ### Fixed
 
 - Keep the transaction-detail fallback chain going when an intermediate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Entries for versions prior to `4.0.0` have been moved to
 [CHANGELOG-archive.md](CHANGELOG-archive.md).
 
+## [4.16.0] - 2026-06-09
+
+### Fixed
+
+- Keep the transaction-detail fallback chain going when an intermediate
+  node returns an error the browser cannot read (e.g. a CORS-blocked or
+  otherwise response-less failure). The lookup previously aborted on the
+  first such error and showed it even when a later ancestor still held
+  the transaction. It now tries every configured ancestor in order and
+  surfaces an error only when all of them fail, restoring `v0.38`
+  transaction lookups when the `v0.45` archive sits earlier in the chain
+
 ## [4.15.0] - 2026-06-08
 
 ### Added
@@ -677,7 +689,8 @@ Entries for versions prior to `4.0.0` have been moved to
 
 - Fix reactivity of account dashboard
 
-[4.15.0]: https://github.com/commercionetwork/almerico/compare/v4.14.1...HEAD
+[4.16.0]: https://github.com/commercionetwork/almerico/compare/v4.15.0...HEAD
+[4.15.0]: https://github.com/commercionetwork/almerico/compare/v4.14.1...v4.15.0
 [4.14.1]: https://github.com/commercionetwork/almerico/compare/v4.13.7...v4.14.1
 [4.14.0]: https://github.com/commercionetwork/almerico/compare/v4.13.7...v4.14.0
 [4.13.7]: https://github.com/commercionetwork/almerico/compare/v4.13.6...v4.13.7

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ you have to:
     VUE_APP_CONNECTIONS=VALUE (e.g., [{"id":"connection-10","chain_id":"osmo-test-5"}])
     VUE_APP_CONTRACT_DEX=VALUE (e.g., did:com:1yva23huwtu5f5tzm9vu3ce4h4y7x9j0q59wvse4t0lrzhhv68tzq5vps96)
     VUE_APP_FIRST_CONVERSION_RATE=VALUE (e.g., 1)
+    # Optional: the explorer auto-detects the node's lowest available block
+    # height; set this only as a fallback for when the node does not report it.
     VUE_APP_FIRST_HEIGHT=VALUE (e.g., 1234)
     VUE_APP_HAS_POOLS=VALUE (e.g., true)
     VUE_APP_LCD=VALUE (e.g., http://lcd.com)
@@ -77,6 +79,8 @@ VUE_APP_BACKEND_WS=VALUE (e.g., wss://backend.com/websocket)
 VUE_APP_CONNECTIONS=VALUE (e.g., [{"id":"connection-8","chain_id":"osmosis-1"}])
 VUE_APP_CONTRACT_DEX=VALUE (e.g., did:com:1yva23huwtu5f5tzm9vu3ce4h4y7x9j0q59wvse4t0lrzhhv68tzq5vps96)
 VUE_APP_FIRST_CONVERSION_RATE=VALUE (e.g., 1)
+# Optional: the explorer auto-detects the node's lowest available block
+# height; set this only as a fallback for when the node does not report it.
 VUE_APP_FIRST_HEIGHT=VALUE (e.g., 1)
 VUE_APP_HAS_POOLS=VALUE (e.g., false)
 VUE_APP_LCD=VALUE (e.g., https://lcd.com)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ npm run test
 npm run lint
 ```
 
+### Transaction detail archive fallback
+
+When opening a transaction detail, the explorer queries the live LCD
+first and, on failure, falls back to the nodes listed in
+`VUE_APP_ANCESTORS` in order (see the env var examples above). This lets
+the explorer resolve transactions that predate the current node's
+history.
+
+The following **mainnet** hashes can be used to manually verify each step of
+the chain (they only resolve through the indicated source):
+
+| Source        | SDK     | Example transaction hash                                           |
+| ------------- | ------- | ------------------------------------------------------------------ |
+| Archive node  | `v0.45` | `4249C26E4C01B95E27233E6EF42A8EF5026CB3E954E3FA6C55862059EBB26188` |
+| Archive node  | `v0.45` | `A090C3667E3AAC0E6B15216772DD75EAEFBBBCC4B34ABA64616440B34F8E5DA1` |
+| Ancestor node | `v0.38` | `11980F8E3C810A994E23B51A250DE709DE5E080725F263E63FED94FB01BB7B53` |
+
+Opening any of these from the transactions detail view should display the
+full transaction, served transparently by the matching fallback node.
+
 ## Docker
 
 ### Build the Docker image

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "almerico",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "almerico",
-      "version": "4.15.0",
+      "version": "4.16.0",
       "license": "MIT",
       "dependencies": {
         "@cosmjs/cosmwasm-stargate": "~0.34.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "almerico",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "explorer of Commercio.network blockchain",
   "private": true,
   "license": "MIT",

--- a/src/constants/blocks-constant.js
+++ b/src/constants/blocks-constant.js
@@ -1,4 +1,8 @@
 export default Object.freeze({
   TABLE_ITEMS: 30,
   SEARCH_ITEMS: 100,
+  // Lowest possible block height, used to probe the node for the first
+  // available height (a pruning node rejects it and reports its lowest one).
+  FIRST_HEIGHT_PROBE: 1,
+  LOWEST_HEIGHT_REGEX: /lowest height is (\d+)/,
 });

--- a/src/constants/config-constant.js
+++ b/src/constants/config-constant.js
@@ -11,11 +11,6 @@ const FIRST_CONVERSION_RATE =
     ? process.env.VUE_APP_FIRST_CONVERSION_RATE
     : '1';
 
-const FIRST_HEIGHT =
-  process.env.VUE_APP_FIRST_HEIGHT !== undefined
-    ? process.env.VUE_APP_FIRST_HEIGHT
-    : '1';
-
 const HAS_POOLS =
   process.env.VUE_APP_HAS_POOLS && process.env.VUE_APP_HAS_POOLS === 'true';
 
@@ -112,7 +107,6 @@ export default Object.freeze({
   COPYRIGHT,
   FEE_AMOUNT,
   FIRST_CONVERSION_RATE,
-  FIRST_HEIGHT,
   GAS_AMOUNT,
   GAS_PRICE_STEP,
   HAS_POOLS,

--- a/src/store/application/__tests__/actions.test.js
+++ b/src/store/application/__tests__/actions.test.js
@@ -8,20 +8,28 @@ import {
   mockValidatorSets,
 } from '@/__mocks__';
 import actions from '../actions.js';
-import { VALIDATORS } from '@/constants';
+import { BLOCKS, VALIDATORS } from '@/constants';
 
 const mockErrorResponse = mockErrors(400);
 let mockError = false;
+let mockRequestBlockError = false;
+let mockLowestHeightMessage = null;
 let mockResponse = null;
 
 describe('store/application/actions', () => {
+  const OLD_ENV = process.env;
+
   beforeEach(() => {
     mockError = false;
+    mockRequestBlockError = false;
+    mockLowestHeightMessage = null;
     mockResponse = null;
+    process.env = { ...OLD_ENV };
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    process.env = OLD_ENV;
   });
 
   test('if "initAppData" reset store, set loading state, dispatch "fetchInfo", "fetchLatestBlock", "fetchLatestValidatorSets, "fetchStakingParams" and "fetchValidators" actions', async () => {
@@ -32,12 +40,55 @@ describe('store/application/actions', () => {
 
     expect(commit).toHaveBeenCalledWith('reset');
     expect(commit).toHaveBeenCalledWith('setLoading', true);
+    expect(dispatch).toHaveBeenCalledWith('fetchFirstHeight');
     expect(dispatch).toHaveBeenCalledWith('fetchInfo');
     expect(dispatch).toHaveBeenCalledWith('fetchLatestBlock');
     expect(dispatch).toHaveBeenCalledWith('fetchLatestValidatorSets');
     expect(dispatch).toHaveBeenCalledWith('fetchStakingParams');
     expect(dispatch).toHaveBeenCalledWith('fetchValidators');
     expect(commit).toHaveBeenCalledWith('setLoading', false);
+  });
+
+  test('if "fetchFirstHeight" commit the probe height when the node holds the whole history', async () => {
+    const commit = jest.fn();
+
+    await actions.fetchFirstHeight({ commit });
+
+    expect(commit).toHaveBeenCalledWith(
+      'setFirstHeight',
+      BLOCKS.FIRST_HEIGHT_PROBE
+    );
+  });
+
+  test('if "fetchFirstHeight" commit the lowest available height reported by a pruning node', async () => {
+    const commit = jest.fn();
+    mockRequestBlockError = true;
+    mockLowestHeightMessage =
+      'height 1 is not available, lowest height is 24972001';
+
+    await actions.fetchFirstHeight({ commit });
+
+    expect(commit).toHaveBeenCalledWith('setFirstHeight', 24972001);
+  });
+
+  test('if "fetchFirstHeight" fall back to the env variable when the node does not report the lowest height', async () => {
+    const commit = jest.fn();
+    mockRequestBlockError = true;
+    process.env.VUE_APP_FIRST_HEIGHT = '500';
+
+    await actions.fetchFirstHeight({ commit });
+
+    expect(commit).toHaveBeenCalledWith('setFirstHeight', 500);
+  });
+
+  test('if "fetchFirstHeight" set the error when the lowest height is unknown and no env fallback is set', async () => {
+    const commit = jest.fn();
+    mockRequestBlockError = true;
+    delete process.env.VUE_APP_FIRST_HEIGHT;
+
+    await actions.fetchFirstHeight({ commit });
+
+    expect(commit).toHaveBeenCalledWith('setError', mockErrorResponse);
   });
 
   test('if "fetchInfo" action commit "setInfo" mutation, and set the error if it is caught', async () => {
@@ -213,6 +264,24 @@ jest.mock('../../../apis/http/staking-api.js', () => ({
 }));
 
 jest.mock('../../../apis/http/tendermintRpc-api.js', () => ({
+  requestBlock: () => {
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (mockRequestBlockError) {
+          reject(
+            mockLowestHeightMessage
+              ? { response: { data: { error: mockLowestHeightMessage } } }
+              : mockErrorResponse
+          );
+        }
+
+        mockResponse = {
+          data: mockBlock(),
+        };
+        resolve(mockResponse);
+      }, 1);
+    });
+  },
   requestBlockLatest: () => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {

--- a/src/store/application/actions.js
+++ b/src/store/application/actions.js
@@ -1,5 +1,5 @@
 import { gaiaRest, monitor, staking, tendermintRpc, tx } from '@/apis/http';
-import { VALIDATORS } from '@/constants';
+import { BLOCKS, VALIDATORS } from '@/constants';
 
 export default {
   async fetchHealth({ commit }) {
@@ -14,6 +14,7 @@ export default {
     commit('reset');
     commit('setLoading', true);
     const requests = [
+      dispatch('fetchFirstHeight'),
       dispatch('fetchInfo'),
       dispatch('fetchLatestBlock'),
       dispatch('fetchLatestValidatorSets'),
@@ -22,6 +23,25 @@ export default {
     ];
     await Promise.all(requests);
     commit('setLoading', false);
+  },
+  async fetchFirstHeight({ commit }) {
+    try {
+      await tendermintRpc.requestBlock(BLOCKS.FIRST_HEIGHT_PROBE);
+      // The probe height is available: the node holds the whole history.
+      commit('setFirstHeight', BLOCKS.FIRST_HEIGHT_PROBE);
+    } catch (error) {
+      const lowestHeight = _parseLowestHeight(error);
+      if (lowestHeight) {
+        commit('setFirstHeight', lowestHeight);
+      } else if (process.env.VUE_APP_FIRST_HEIGHT) {
+        // Use the env variable and not a constant to make the action testable.
+        // It is only a fallback for when the node does not report its lowest
+        // available height (truthy check also covers an empty Docker default).
+        commit('setFirstHeight', parseInt(process.env.VUE_APP_FIRST_HEIGHT));
+      } else {
+        commit('setError', error);
+      }
+    }
   },
   async fetchInfo({ commit }) {
     try {
@@ -99,4 +119,16 @@ export default {
     await dispatch('fetchValidators');
     commit('setLoading', false);
   },
+};
+
+const _parseLowestHeight = (error) => {
+  const message =
+    error && error.response && error.response.data
+      ? error.response.data.error || error.response.data.message
+      : null;
+  if (!message) {
+    return null;
+  }
+  const match = message.match(BLOCKS.LOWEST_HEIGHT_REGEX);
+  return match ? parseInt(match[1]) : null;
 };

--- a/src/store/application/getters.js
+++ b/src/store/application/getters.js
@@ -3,6 +3,7 @@ export default {
   isLoading: (state) => state.isLoading,
   isMaintenance: (state) => state.maintenance,
   eventHeight: (state) => state.eventHeight,
+  firstHeight: (state) => state.firstHeight,
   info: (state) => state.info,
   latestBlock: (state) => state.latestBlock,
   latestTransactions: (state) => state.latestTransactions,

--- a/src/store/application/index.js
+++ b/src/store/application/index.js
@@ -6,6 +6,7 @@ export const initState = () => ({
   error: null,
   isLoading: false,
   eventHeight: null,
+  firstHeight: null,
   info: null,
   latestBlock: null,
   latestTransactions: [],

--- a/src/store/application/mutations.js
+++ b/src/store/application/mutations.js
@@ -16,6 +16,9 @@ export default {
   setEventHeight(state, payload) {
     state.eventHeight = payload;
   },
+  setFirstHeight(state, payload) {
+    state.firstHeight = payload;
+  },
   setInfo(state, payload) {
     state.info = payload;
   },

--- a/src/store/blocks/__tests__/actions.test.js
+++ b/src/store/blocks/__tests__/actions.test.js
@@ -43,8 +43,9 @@ describe('store/blocks/actions', () => {
     const height = '1000';
     let maxHeight = parseInt(height);
     let minHeight = maxHeight - BLOCKS.TABLE_ITEMS;
+    const rootGetters = { 'application/firstHeight': 1 };
 
-    await actions.fetchBlocks({ commit, dispatch }, height);
+    await actions.fetchBlocks({ commit, dispatch, rootGetters }, height);
 
     expect(dispatch).toHaveBeenCalledTimes(BLOCKS.TABLE_ITEMS);
     while (maxHeight > minHeight) {
@@ -59,8 +60,9 @@ describe('store/blocks/actions', () => {
     const height = '1000';
     let maxHeight = parseInt(height);
     let minHeight = maxHeight - BLOCKS.SEARCH_ITEMS;
+    const rootGetters = { 'application/firstHeight': 1 };
 
-    await actions.searchBlocks({ commit, dispatch }, height);
+    await actions.searchBlocks({ commit, dispatch, rootGetters }, height);
 
     expect(commit).toHaveBeenCalledWith('setBlocks', []);
     expect(commit).toHaveBeenCalledWith('setCurrentHeight', '');

--- a/src/store/blocks/actions.js
+++ b/src/store/blocks/actions.js
@@ -1,5 +1,5 @@
 import { blocks, tendermintRpc, tx } from '@/apis/http';
-import { BLOCKS, CONFIG } from '@/constants';
+import { BLOCKS } from '@/constants';
 import { blocksRequestHelper } from '@/utils';
 
 export default {
@@ -11,9 +11,9 @@ export default {
     commit('setLoading', false);
   },
 
-  async fetchBlocks({ commit, dispatch }, height) {
+  async fetchBlocks({ commit, dispatch, rootGetters }, height) {
     const max = typeof height === 'number' ? height : parseInt(height);
-    const min = parseInt(CONFIG.FIRST_HEIGHT);
+    const min = rootGetters['application/firstHeight'];
     const minimumHeight = blocksRequestHelper.getMinimumHeight({
       max,
       min,
@@ -29,12 +29,12 @@ export default {
     commit('setCurrentHeight', minimumHeight);
   },
 
-  async searchBlocks({ commit, dispatch }, height) {
+  async searchBlocks({ commit, dispatch, rootGetters }, height) {
     commit('setBlocks', []);
     commit('setCurrentHeight', '');
     commit('setSearching', true);
     const max = typeof height === 'number' ? height : parseInt(height);
-    const min = parseInt(CONFIG.FIRST_HEIGHT);
+    const min = rootGetters['application/firstHeight'];
     const minimumHeight = blocksRequestHelper.getMinimumHeight({
       max,
       min,

--- a/src/store/home/__tests__/actions.test.js
+++ b/src/store/home/__tests__/actions.test.js
@@ -101,8 +101,9 @@ describe('store/home/actions', () => {
 
   test('if "fetchStartingDate" action commit "setStartingDate", and set the error if it is caught', async () => {
     const commit = jest.fn();
+    const rootGetters = { 'application/firstHeight': 1 };
 
-    await actions.fetchStartingDate({ commit });
+    await actions.fetchStartingDate({ commit, rootGetters });
 
     expect(commit).toHaveBeenCalledWith(
       'setStartingDate',
@@ -111,7 +112,7 @@ describe('store/home/actions', () => {
 
     mockError = true;
 
-    await actions.fetchStartingDate({ commit });
+    await actions.fetchStartingDate({ commit, rootGetters });
 
     expect(commit).toHaveBeenCalledWith('setError', mockErrorResponse);
   });

--- a/src/store/home/actions.js
+++ b/src/store/home/actions.js
@@ -1,5 +1,5 @@
 import { chart, commercio, tendermintRpc, tx } from '@/apis/http';
-import { APIS, HOME, CONFIG } from '@/constants';
+import { APIS, HOME } from '@/constants';
 
 export default {
   async initHome({ commit, dispatch }) {
@@ -59,9 +59,11 @@ export default {
     commit('setLoadingParams', false);
   },
 
-  async fetchStartingDate({ commit }) {
+  async fetchStartingDate({ commit, rootGetters }) {
     try {
-      const response = await tendermintRpc.requestBlock(CONFIG.FIRST_HEIGHT);
+      const response = await tendermintRpc.requestBlock(
+        rootGetters['application/firstHeight']
+      );
       commit('setStartingDate', response.data.block.header.time);
     } catch (error) {
       commit('setError', error);

--- a/src/store/transactions/__tests__/actions.test.js
+++ b/src/store/transactions/__tests__/actions.test.js
@@ -9,9 +9,11 @@ import actions from '../actions.js';
 
 const mockErrorResponse = mockErrors(400);
 const mockErrorResponseNotFound = mockErrors(404);
+const mockErrorResponseNetwork = mockErrors(undefined);
 let mockError = false;
 let mockErrorNotFound = false;
 let mockArchiveNotFound = false;
+let mockArchiveNetworkError = false;
 let mockResponse = null;
 
 describe('store/transactions/actions', () => {
@@ -21,6 +23,7 @@ describe('store/transactions/actions', () => {
     mockError = false;
     mockErrorNotFound = false;
     mockArchiveNotFound = false;
+    mockArchiveNetworkError = false;
     mockResponse = null;
     jest.resetModules();
     process.env = { ...OLD_ENV };
@@ -189,7 +192,7 @@ describe('store/transactions/actions', () => {
     );
   });
 
-  test('if "fetchAncestorsTransaction" sets the error when the archive node fails with a non-404 status', async () => {
+  test('if "fetchAncestorsTransaction" falls back to the next ancestor when the archive node fails with an unreadable (CORS/network) error', async () => {
     const commit = jest.fn();
     const hash = 'hash';
     const ancestors = [
@@ -204,12 +207,16 @@ describe('store/transactions/actions', () => {
         ver: '0.38',
       },
     ];
-    mockError = true;
+    mockArchiveNetworkError = true;
 
     await actions.fetchAncestorsTransaction({ commit }, { hash, ancestors });
 
-    expect(commit).toHaveBeenCalledWith('setError', mockErrorResponse);
-    expect(commit).not.toHaveBeenCalledWith('setDetail', expect.anything());
+    expect(commit).toHaveBeenCalledWith('setDetail', {
+      data: mockResponse.data,
+      ledger: ancestors[1].lcd_ledger,
+      version: ancestors[1].ver,
+    });
+    expect(commit).not.toHaveBeenCalledWith('setError', expect.anything());
   });
 });
 
@@ -273,6 +280,9 @@ jest.mock('../../../apis/http/tx-api.js', () => ({
   requestTxByHashArchive: () => {
     return new Promise((resolve, reject) => {
       setTimeout(() => {
+        if (mockArchiveNetworkError) {
+          reject(mockErrorResponseNetwork);
+        }
         if (mockArchiveNotFound || mockErrorNotFound) {
           reject(mockErrorResponseNotFound);
         }

--- a/src/store/transactions/actions.js
+++ b/src/store/transactions/actions.js
@@ -50,7 +50,12 @@ export default {
     }
   },
   async fetchAncestorsTransaction({ commit }, { hash, ancestors }) {
-    for (const [i, ancestor] of ancestors.entries()) {
+    // Query each ancestor in order and stop at the first hit. A failing
+    // ancestor (404, non-404 status, or a CORS/network error that leaves
+    // the response unreadable) must not abort the chain: only commit the
+    // error once every ancestor has been tried without success.
+    let lastError;
+    for (const ancestor of ancestors) {
       try {
         const response = await _requestToAncestor(hash, ancestor);
         commit('setDetail', {
@@ -58,19 +63,12 @@ export default {
           ledger: ancestor.lcd_ledger,
           version: ancestor.ver,
         });
-        break;
+        return;
       } catch (error) {
-        if (
-          i < ancestors.length - 1 &&
-          error.response &&
-          error.response.status === 404
-        ) {
-          continue;
-        } else {
-          commit('setError', error);
-        }
+        lastError = error;
       }
     }
+    commit('setError', lastError);
   },
 };
 

--- a/src/views/blocks/BlocksViewList.vue
+++ b/src/views/blocks/BlocksViewList.vue
@@ -23,7 +23,6 @@
 import BlocksViewListTable from './list/BlocksViewListTable.vue';
 import BlocksViewListContentTop from './list/BlocksViewListContentTop.vue';
 
-import { CONFIG } from '@/constants';
 import { mapActions, mapGetters } from 'vuex';
 
 export default {
@@ -38,11 +37,8 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('application', ['latestBlock']),
+    ...mapGetters('application', ['latestBlock', 'firstHeight']),
     ...mapGetters('blocks', ['error', 'isLoading', 'newHeight']),
-    firstHeight() {
-      return parseInt(CONFIG.FIRST_HEIGHT);
-    },
     lastHeight() {
       return this.latestBlock.header.height;
     },

--- a/src/views/blocks/list/BlocksViewListSearch.vue
+++ b/src/views/blocks/list/BlocksViewListSearch.vue
@@ -20,7 +20,7 @@
                     </template>
                     <i18n tag="span" path="msgs.searchBlocksInfo">
                       <span v-text="BLOCKS.SEARCH_ITEMS" />
-                      <span v-text="CONFIG.FIRST_HEIGHT" />
+                      <span v-text="firstHeight" />
                     </i18n>
                   </v-tooltip>
                 </template>
@@ -46,19 +46,22 @@
 </template>
 
 <script>
-import { BLOCKS, CONFIG } from '@/constants';
+import { BLOCKS } from '@/constants';
 import { mdiInformationOutline, mdiMagnify } from '@mdi/js';
+import { mapGetters } from 'vuex';
 
 export default {
   name: 'BlocksViewListSearch',
   data() {
     return {
       BLOCKS,
-      CONFIG,
       mdiInformationOutline,
       mdiMagnify,
       model: { height: '' },
     };
+  },
+  computed: {
+    ...mapGetters('application', ['firstHeight']),
   },
   methods: {
     search(isSearching) {


### PR DESCRIPTION
**Changelog**

### Changed

- Auto-detect the node's lowest available block height instead of relying
  on `VUE_APP_FIRST_HEIGHT`. On startup the explorer probes the node and,
  on a pruning node, reads the lowest height it reports; the env variable
  is now an optional fallback used only when the node does not provide it

### Fixed

- Keep the transaction-detail fallback chain going when an intermediate
  node returns an error the browser cannot read (e.g. a CORS-blocked or
  otherwise response-less failure), trying every configured ancestor in
  order and surfacing an error only when all of them fail